### PR TITLE
Allow templatizing proxysql.cnf from env variables.

### DIFF
--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Ratnadeep Debnath <ratnadeep.debnath@zapier.com>
 ENV VERSION 1.4.14
 
 RUN apt-get update && \
-    apt-get install -y wget mysql-client inotify-tools procps && \
+    apt-get install -y wget mysql-client inotify-tools procps gettext-base && \
     wget https://github.com/sysown/proxysql/releases/download/v${VERSION}/proxysql_${VERSION}-debian9_amd64.deb -O /opt/proxysql_${VERSION}-debian9_amd64.deb && \
     dpkg -i /opt/proxysql_${VERSION}-debian9_amd64.deb && \
     rm -f /opt/proxysql_${VERSION}-debian9_amd64.deb && \

--- a/1.4/entrypoint.sh
+++ b/1.4/entrypoint.sh
@@ -9,6 +9,11 @@ set -e
 ## MONITOR_CONFIG_CHANGE={true|false}
 ## - Monitor /etc/proxysql.cnf for any changes and reload ProxySQL automatically
 
+# Render /etc/proxysql.cnf from proxysql.cnf template
+if [ -f /tmp/proxysql.cnf ]; then
+	cat /tmp/proxysql.cnf | envsubst > /etc/proxysql.cnf
+fi
+
 # If command has arguments, prepend proxysql
 if [ "${1:0:1}" = '-' ]; then
 	CMDARG="$@"


### PR DESCRIPTION
This is will help us to render passwords into the /etc/proxysql.cnf
from env variables.