### PR TITLE
Tweak entrypoint script to handle graceful shutdown via SIGTERM.

### DIFF
--- a/1.4/entrypoint.sh
+++ b/1.4/entrypoint.sh
@@ -3,11 +3,6 @@ set -e
 
 ## ProxySQL entrypoint
 ## ===================
-##
-## Supported environment variable:
-##
-## MONITOR_CONFIG_CHANGE={true|false}
-## - Monitor /etc/proxysql.cnf for any changes and reload ProxySQL automatically
 
 # Render /etc/proxysql.cnf from proxysql.cnf template
 if [ -f /tmp/proxysql.cnf ]; then
@@ -19,30 +14,14 @@ if [ "${1:0:1}" = '-' ]; then
 	CMDARG="$@"
 fi
 
-if [ $MONITOR_CONFIG_CHANGE ]; then
+trap handle_term SIGTERM
 
-	echo 'Env MONITOR_CONFIG_CHANGE=true'
-	CONFIG=/etc/proxysql.cnf
-	oldcksum=$(cksum ${CONFIG})
+handle_term() {
+    echo "SIGTERM received... Shutting down proxysql gracefully..."
+    pkill -f proxysql
+    echo "Exit code of proxysql: $?"
+    exit 0
+}
 
-	# Start ProxySQL in the background
-	proxysql --reload -f $CMDARG &
-
-	echo "Monitoring $CONFIG for changes.."
-	inotifywait -e modify,move,create,delete -m --timefmt '%d/%m/%y %H:%M' --format '%T' ${CONFIG} | \
-	while read date time; do
-		newcksum=$(cksum ${CONFIG})
-		if [ "$newcksum" != "$oldcksum" ]; then
-			echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-			echo "At ${time} on ${date}, ${CONFIG} update detected."
-			echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-			oldcksum=$newcksum
-			echo "Reloading ProxySQL.."
-		        killall -15 proxysql
-			proxysql --initial --reload -f $CMDARG
-		fi
-	done
-fi
-
-# Start ProxySQL with PID 1
-exec proxysql -f $CMDARG
+exec proxysql -f $CMDARG &
+wait $!


### PR DESCRIPTION
`inotifywait ` logic has also been removed since we don't need this in the k8s world. The image has been published as `proxysql:1.4.14-2`.

You can test this as follows:

```
docker run -it 996097627176.dkr.ecr.us-east-1.amazonaws.com/proxysql:1.4.14-2
```

And, in another shell:

```
docker stop <container_id>
```