### PR TITLE
IE-1255 Allow graceful shutdown for ProxySQL container.

### DIFF
--- a/1.4/entrypoint.sh
+++ b/1.4/entrypoint.sh
@@ -16,8 +16,13 @@ fi
 
 trap handle_term SIGTERM
 
+PROXYSQL_SHUTDOWN_GRACE_PERIOD=${PROXYSQL_SHUTDOWN_GRACE_PERIOD:=20}
+
 handle_term() {
-    echo "SIGTERM received... Shutting down proxysql gracefully..."
+    echo "SIGTERM received..."
+    echo "Waiting for $PROXYSQL_SHUTDOWN_GRACE_PERIOD seconds to existing connections to complete..."
+    sleep $PROXYSQL_SHUTDOWN_GRACE_PERIOD
+    echo "Killing ProxySQL..."
     pkill -f proxysql
     echo "Exit code of proxysql: $?"
     exit 0

--- a/2.0.2/entrypoint.sh
+++ b/2.0.2/entrypoint.sh
@@ -16,8 +16,13 @@ fi
 
 trap handle_term SIGTERM
 
+PROXYSQL_SHUTDOWN_GRACE_PERIOD=${PROXYSQL_SHUTDOWN_GRACE_PERIOD:=20}
+
 handle_term() {
-    echo "SIGTERM received... Shutting down proxysql gracefully..."
+    echo "SIGTERM received..."
+    echo "Waiting for $PROXYSQL_SHUTDOWN_GRACE_PERIOD seconds to existing connections to complete..."
+    sleep $PROXYSQL_SHUTDOWN_GRACE_PERIOD
+    echo "Killing ProxySQL..."
     pkill -f proxysql
     echo "Exit code of proxysql: $?"
     exit 0


### PR DESCRIPTION
Fixes: https://zapierorg.atlassian.net/browse/IE-1255

This adds configurable `sleep` in the `SIGTERM` handler to allow proxysql to complete existing client connections. In the meantime, Kubernetes will stop sending new connections the pod. This will act like connection drain for the ProxySQL pod.