### PR TITLE
Handle missing global_stats during collectiong ProxySQL metrics

### DIFF
--- a/metrics/proxysql.py
+++ b/metrics/proxysql.py
@@ -17,7 +17,10 @@ import pymysql.cursors
 from datadog.dogstatsd.base import DogStatsd
 
 logger = logging.getLogger()
-logger.addHandler(logging.StreamHandler())
+handler = logging.StreamHandler()
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+logger.addHandler(handler)
 logger.setLevel(os.environ.get('LOGLEVEL', 'INFO'))
 
 GAUGE = "gauge"

--- a/metrics/proxysql.py
+++ b/metrics/proxysql.py
@@ -95,10 +95,11 @@ class ProxySQLMetrics:
     def _collect_metrics(self, conn, tags, options):
         """Collects all the different types of ProxySQL metrics and submits them to Datadog"""
         global_stats = self._get_global_stats(conn)
-        for proxysql_metric_name, metric_details in PROXYSQL_MYSQL_STATS_GLOBAL.items():
-            metric_name, metric_type = metric_details
-            metric_tags = list(tags)
-            self._submit_metric(metric_name, metric_type, float(global_stats.get(proxysql_metric_name)), metric_tags)
+        if global_stats:
+            for proxysql_metric_name, metric_details in PROXYSQL_MYSQL_STATS_GLOBAL.items():
+                metric_name, metric_type = metric_details
+                metric_tags = list(tags)
+                self._submit_metric(metric_name, metric_type, float(global_stats.get(proxysql_metric_name)), metric_tags)
 
         report_command_counters = options.get('extra_command_counter_metrics', True)
         if report_command_counters:


### PR DESCRIPTION
Sometimes, due to https://github.com/sysown/proxysql/issues/1866, the metrics script fails to fetch `global_stats` metrics from ProxySQL. As a result, the metrics process used to throw exceptions. This pull request fixes this issue. It also improves the log messages by adding a log `formatter`.