### PR TITLE
Update to ProxySQL 2.0.7.

### DIFF
--- a/2.0.x/Dockerfile
+++ b/2.0.x/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch
 MAINTAINER Ratnadeep Debnath <ratnadeep.debnath@zapier.com>
 
-ENV VERSION 2.0.4
+ENV VERSION 2.0.7
 
 RUN apt-get update && \
     apt-get install -y wget mysql-client inotify-tools procps gettext-base && \

--- a/2.0.x/entrypoint.sh
+++ b/2.0.x/entrypoint.sh
@@ -14,19 +14,4 @@ if [ "${1:0:1}" = '-' ]; then
 	CMDARG="$@"
 fi
 
-trap handle_term SIGTERM
-
-PROXYSQL_SHUTDOWN_GRACE_PERIOD=${PROXYSQL_SHUTDOWN_GRACE_PERIOD:=20}
-
-handle_term() {
-    echo "SIGTERM received..."
-    echo "Waiting for $PROXYSQL_SHUTDOWN_GRACE_PERIOD seconds to existing connections to complete..."
-    sleep $PROXYSQL_SHUTDOWN_GRACE_PERIOD
-    echo "Killing ProxySQL..."
-    pkill -f proxysql
-    echo "Exit code of proxysql: $?"
-    exit 0
-}
-
 exec proxysql -f $CMDARG &
-wait $!


### PR DESCRIPTION
Also, remove handling SIGTERM in the container image for graceful shutdown as the same can be handled with Kubernetes pod lifecycle hooks.